### PR TITLE
feature(mv-refresh): add support to minimum interval between 2 refresh

### DIFF
--- a/lambdas/nodejs/analytics-refresh-mv/README.md
+++ b/lambdas/nodejs/analytics-refresh-mv/README.md
@@ -28,7 +28,15 @@ All the parameters are read from environment variables:
 - `VIEWS_SCHEMAS_NAMES` a json array of strings where each element is a database 
   schema to inspect for stale materialized views.
 - `PROCEDURES_SCHEMA` the name of the redshift schema where the procedure are declared.
-
+- `INCREMENTAL_MV_MIN_INTERVAL`, this optional parameter contain the minimum number of seconds 
+   between two refresh of the same materialized view. This parameter apply to materialized views 
+   that are refreshed incrementally. If not given default value is 0.
+- `NOT_INCREMENTAL_MV_MIN_INTERVAL`, this optional parameter contain the minimum number of seconds 
+   between two refresh of the same materialized view. This parameter apply to materialized views 
+   that are refreshed with full recalculation and materialized views with refresh issues. If not 
+   given default value is 0. Technically this parameter is used for every materialized view with 
+   `state` field of table [SVV_MV_INFO](https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_MV_INFO.html)
+   not equal to 1.
 
 ## Algorithm
 The used algorithm is:
@@ -37,7 +45,12 @@ The used algorithm is:
   listing the result with
   ```sql
     SELECT
-      mv_schema, mv_name, mv_level
+      mv_schema, mv_name, mv_level,
+      incremental_refresh_not_supported, 
+      last_refresh_start_time, 
+      last_refresh_end_time,
+      last_refresh_start_time_epoch,
+      last_refresh_end_time_epoch
     FROM
       list_need_refresh_views_results
     ORDER BY

--- a/lambdas/nodejs/analytics-refresh-mv/README.md
+++ b/lambdas/nodejs/analytics-refresh-mv/README.md
@@ -28,10 +28,10 @@ All the parameters are read from environment variables:
 - `VIEWS_SCHEMAS_NAMES` a json array of strings where each element is a database 
   schema to inspect for stale materialized views.
 - `PROCEDURES_SCHEMA` the name of the redshift schema where the procedure are declared.
-- `INCREMENTAL_MV_MIN_INTERVAL`, this optional parameter contain the minimum number of seconds 
+- `INCREMENTAL_MV_MIN_INTERVAL_SECONDS`, this optional parameter contain the minimum number of seconds 
    between two refresh of the same materialized view. This parameter apply to materialized views 
    that are refreshed incrementally. If not given default value is 0.
-- `NOT_INCREMENTAL_MV_MIN_INTERVAL`, this optional parameter contain the minimum number of seconds 
+- `NOT_INCREMENTAL_MV_MIN_INTERVAL_SECONDS`, this optional parameter contain the minimum number of seconds 
    between two refresh of the same materialized view. This parameter apply to materialized views 
    that are refreshed with full recalculation and materialized views with refresh issues. If not 
    given default value is 0. Technically this parameter is used for every materialized view with 

--- a/lambdas/nodejs/analytics-refresh-mv/dot_env.template
+++ b/lambdas/nodejs/analytics-refresh-mv/dot_env.template
@@ -7,3 +7,10 @@ REDSHIFT_DB_USER="dev_mv_refresher_user"
 
 VIEWS_SCHEMAS_NAMES='["views", "sub_views"]'
 PROCEDURES_SCHEMA="sub_views"
+
+# ### optional parameters
+# - Minimum interval between two refresh of the same view; applied to incremental refresh views
+# INCREMENTAL_MV_MIN_INTERVAL="120" # 2 minutes
+# - Minimum interval between two refresh of the same view; applied to not incremental views.
+#   Not incremental refresh means: full refresh views and not refresh-able views.
+# NOT_INCREMENTAL_MV_MIN_INTERVAL="900" # 15 minutes

--- a/lambdas/nodejs/analytics-refresh-mv/dot_env.template
+++ b/lambdas/nodejs/analytics-refresh-mv/dot_env.template
@@ -10,7 +10,7 @@ PROCEDURES_SCHEMA="sub_views"
 
 # ### optional parameters
 # - Minimum interval between two refresh of the same view; applied to incremental refresh views
-# INCREMENTAL_MV_MIN_INTERVAL="120" # 2 minutes
+# INCREMENTAL_MV_MIN_INTERVAL_SECONDS="120" # 2 minutes
 # - Minimum interval between two refresh of the same view; applied to not incremental views.
 #   Not incremental refresh means: full refresh views and not refresh-able views.
-# NOT_INCREMENTAL_MV_MIN_INTERVAL="900" # 15 minutes
+# NOT_INCREMENTAL_MV_MIN_INTERVAL_SECONDS="900" # 15 minutes

--- a/lambdas/nodejs/analytics-refresh-mv/eslint.config.mjs
+++ b/lambdas/nodejs/analytics-refresh-mv/eslint.config.mjs
@@ -5,7 +5,7 @@ import tseslint from "typescript-eslint";
 
 export default tseslint.config(
   {
-    files: ['**/*.ts'],
+    files: ['src/**/*.ts'],
     extends: [
       eslint.configs.recommended,
       tseslint.configs.recommended,

--- a/lambdas/nodejs/analytics-refresh-mv/src/StaleMaterializedViewFilter.ts
+++ b/lambdas/nodejs/analytics-refresh-mv/src/StaleMaterializedViewFilter.ts
@@ -1,0 +1,97 @@
+import { ViewAndLevel } from "./ViewAndLevel";
+
+type RefreshFrequencyFilter = {
+  minimumRefreshDelaySeconds: number
+}
+
+export class StaleMaterializedViewFilter {
+  
+  #incrementalRefreshFilter: RefreshFrequencyFilter;
+  #notIncrementalRefreshFilter: RefreshFrequencyFilter;
+
+  constructor( env: NodeJS.ProcessEnv ) {
+    console.log("Configuring filters:")
+    
+    this.#incrementalRefreshFilter = this.#configureFilter( env, "INCREMENTAL_MV_MIN_INTERVAL" );
+    console.log(" - Incremental views min delay:", this.#incrementalRefreshFilter)
+
+    this.#notIncrementalRefreshFilter = this.#configureFilter( env, "NOT_INCREMENTAL_MV_MIN_INTERVAL" );
+    console.log(" - Not incremental views min delay:", this.#notIncrementalRefreshFilter)
+  }
+
+  #configureFilter( env: NodeJS.ProcessEnv, name: string ) {
+    let filter: RefreshFrequencyFilter;
+
+    const envValue = env[ name ];
+    if ( envValue ) {
+      const intValue = (+ envValue)
+      if( !isNaN( intValue ) ) {
+        filter = { minimumRefreshDelaySeconds: intValue }
+      }
+      else {
+        const msg = "Error parsing " + name + " environment variable: " + envValue + " is not parsable to integer";
+        console.error( msg );
+        throw new Error(msg );
+      }
+    }
+    else {
+      filter = { minimumRefreshDelaySeconds: 0 }
+    }
+
+    return filter;
+  }
+
+  async filterAll(
+    materializedViewList: ViewAndLevel[], 
+    removeListener: (( mv: ViewAndLevel|null, r: number ) => void) | null = null
+  ) {
+    const filteredList = [];
+    
+    const nowEpoch = this.#currentUtcEpochSeconds();
+    console.log(" - Filtering using epoch " + nowEpoch );
+
+    let removed = 0;
+    for( const mv of materializedViewList ) {
+      const keep = await this.#testOne( mv, nowEpoch );
+      if( keep ) {
+        filteredList.push( mv );
+      }
+      else {
+        console.log(" - Not refreshing materialized view ", mv)
+        if( removeListener ) {
+          removeListener( mv, removed )
+        }
+        removed += 1;
+      }
+    }
+    
+    if( removeListener ) {
+      removeListener( null, removed );
+    }
+    
+    console.log("Removed "+ removed + " views.");
+    return filteredList;
+  }
+  
+  #currentUtcEpochSeconds() {
+    return Math.ceil( new Date().getTime() / 1000 );
+  }
+
+  #testOne( el: ViewAndLevel, nowEpoch: number ): boolean {
+    let result: boolean;
+    if( el.incrementalRefreshNotSupported ) {
+      result = this.#applyFilter( el, this.#notIncrementalRefreshFilter, nowEpoch );
+    }
+    else {
+      result = this.#applyFilter( el, this.#incrementalRefreshFilter, nowEpoch );
+    }
+    return result;
+  }
+
+  #applyFilter( el: ViewAndLevel, filter: RefreshFrequencyFilter, nowEpoch: number): boolean {
+    const lastRefreshLimit = nowEpoch - filter.minimumRefreshDelaySeconds;
+
+    return el.lastRefreshEndTimeEpoch < lastRefreshLimit;
+  }
+
+}

--- a/lambdas/nodejs/analytics-refresh-mv/src/StaleMaterializedViewFilter.ts
+++ b/lambdas/nodejs/analytics-refresh-mv/src/StaleMaterializedViewFilter.ts
@@ -29,7 +29,7 @@ export class StaleMaterializedViewFilter {
         filter = { minimumRefreshDelaySeconds: intValue }
       }
       else {
-        const msg = "Error parsing " + name + " environment variable: " + envValue + " is not parsable to integer";
+        const msg = "Error parsing " + name + " environment variable: " + envValue + " is not parsable as integer";
         console.error( msg );
         throw new Error(msg );
       }

--- a/lambdas/nodejs/analytics-refresh-mv/src/StaleMaterializedViewFilter.ts
+++ b/lambdas/nodejs/analytics-refresh-mv/src/StaleMaterializedViewFilter.ts
@@ -12,10 +12,10 @@ export class StaleMaterializedViewFilter {
   constructor( env: NodeJS.ProcessEnv ) {
     console.log("Configuring filters:")
     
-    this.#incrementalRefreshFilter = this.#configureFilter( env, "INCREMENTAL_MV_MIN_INTERVAL" );
+    this.#incrementalRefreshFilter = this.#configureFilter( env, "INCREMENTAL_MV_MIN_INTERVAL_SECONDS" );
     console.log(" - Incremental views min delay:", this.#incrementalRefreshFilter)
 
-    this.#notIncrementalRefreshFilter = this.#configureFilter( env, "NOT_INCREMENTAL_MV_MIN_INTERVAL" );
+    this.#notIncrementalRefreshFilter = this.#configureFilter( env, "NOT_INCREMENTAL_MV_MIN_INTERVAL_SECONDS" );
     console.log(" - Not incremental views min delay:", this.#notIncrementalRefreshFilter)
   }
 

--- a/lambdas/nodejs/analytics-refresh-mv/src/ViewAndLevel.ts
+++ b/lambdas/nodejs/analytics-refresh-mv/src/ViewAndLevel.ts
@@ -1,0 +1,11 @@
+
+export type ViewAndLevel = {
+    mvSchemaName: string;
+    mvName: string;
+    mvLevel: number;
+    incrementalRefreshNotSupported: boolean;
+    lastRefreshStartTime?: string;
+    lastRefreshStartTimeEpoch: number;
+    lastRefreshEndTime?: string;
+    lastRefreshEndTimeEpoch: number;
+};

--- a/lambdas/nodejs/analytics-refresh-mv/src/groupMaterializedViews.ts
+++ b/lambdas/nodejs/analytics-refresh-mv/src/groupMaterializedViews.ts
@@ -1,4 +1,4 @@
-import { ViewAndLevel } from "./MaterializedViewHelper";
+import { ViewAndLevel } from "./ViewAndLevel";
 import { intToStringWithZeroPadding } from "./utils";
 
 // - Group by level
@@ -19,7 +19,10 @@ export function groupMaterializedViews( infos: ViewAndLevel[]): ViewAndLevel[][]
   })
 
   const grouped: ViewAndLevel[][] = [];
-  for( const key of Object.keys( tmp).sort() ) {
+  const sortedLevelKeys = Object.keys( tmp ).sort();
+  console.log(" - Stale levels array is ", sortedLevelKeys );
+
+  for( const key of sortedLevelKeys ) {
     grouped.push( tmp[key] )
   }
   return grouped;

--- a/lambdas/nodejs/analytics-refresh-mv/test/unit/RedshiftClusterChecker.test.ts
+++ b/lambdas/nodejs/analytics-refresh-mv/test/unit/RedshiftClusterChecker.test.ts
@@ -6,6 +6,7 @@ import { RedshiftClient, DescribeClustersCommand } from '@aws-sdk/client-redshif
 
 // We spy on console.error to ensure it's called without polluting test logs.
 vi.spyOn(console, 'error').mockImplementation(() => {});
+vi.spyOn(console, 'log').mockImplementation(() => {});
 
 // Mock the entire AWS SDK Redshift client module.
 // This allows us to control the behavior of the RedshiftClient and its 'send' method.

--- a/lambdas/nodejs/analytics-refresh-mv/test/unit/RedshiftDataWrapper.test.ts
+++ b/lambdas/nodejs/analytics-refresh-mv/test/unit/RedshiftDataWrapper.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { RedshiftDataWrapper } from '../../src/RedshiftDataWrapper';
 import { StatementError } from '../../src/StatementError';
-import { RedshiftData } from '@aws-sdk/client-redshift-data';
 
 // --- Mock Setup ---
 // We create mock functions for each method on RedshiftData that our class uses.

--- a/lambdas/nodejs/analytics-refresh-mv/test/unit/StaleMaterializedViewFilter.test.ts
+++ b/lambdas/nodejs/analytics-refresh-mv/test/unit/StaleMaterializedViewFilter.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StaleMaterializedViewFilter } from '../../src/StaleMaterializedViewFilter';
+import { ViewAndLevel } from '../../src/ViewAndLevel';
+
+// Suppress console output during tests
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+
+describe('StaleMaterializedViewFilter', () => {
+
+  // --- 1. CONSTRUCTOR TESTS (Corrected) ---
+  // These tests verify the constructor's configuration by observing the
+  // public behavior of the `filterAll` method. This avoids trying to
+  // access private fields directly.
+  // ======================================================================================
+  describe('Constructor', () => {
+    
+    // Use fake timers to control the "current" time for these tests
+    const NOW_DATE = new Date('2025-09-12T10:00:00.000Z');
+    const NOW_EPOCH = Math.ceil(NOW_DATE.getTime() / 1000);
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW_DATE);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should apply the INCREMENTAL_MV_MIN_INTERVAL correctly', async () => {
+      const mockEnv = { INCREMENTAL_MV_MIN_INTERVAL: '300' }; // 5 minutes
+      const filter = new StaleMaterializedViewFilter(mockEnv);
+      
+      const staleMv: ViewAndLevel = {
+        mvName: 'stale', mvSchemaName: 's', mvLevel: 1, incrementalRefreshNotSupported: false,
+        lastRefreshStartTimeEpoch: 0,
+        lastRefreshEndTimeEpoch: NOW_EPOCH - 301 // Refreshed just over 5 mins ago -> should be kept
+      };
+      const recentMv: ViewAndLevel = {
+        mvName: 'recent', mvSchemaName: 's', mvLevel: 1, incrementalRefreshNotSupported: false,
+        lastRefreshStartTimeEpoch: 0,
+        lastRefreshEndTimeEpoch: NOW_EPOCH - 299 // Refreshed just under 5 mins ago -> should be removed
+      };
+      
+      const result: ViewAndLevel[] = await filter.filterAll([staleMv, recentMv]);
+      expect(result).toHaveLength(1);
+      expect(result[0].mvName).toBe('stale');
+    });
+
+    it('should apply the NOT_INCREMENTAL_MV_MIN_INTERVAL correctly', async () => {
+      const mockEnv = { NOT_INCREMENTAL_MV_MIN_INTERVAL: '3600' }; // 1 hour
+      const filter = new StaleMaterializedViewFilter(mockEnv);
+      
+      const staleMv: ViewAndLevel = {
+        mvName: 'stale', mvSchemaName: 's', mvLevel: 1, incrementalRefreshNotSupported: true,
+        lastRefreshStartTimeEpoch: 0,
+        lastRefreshEndTimeEpoch: NOW_EPOCH - 3601 // Refreshed just over 1 hour ago -> should be kept
+      };
+      const recentMv: ViewAndLevel = {
+        mvName: 'recent', mvSchemaName: 's', mvLevel: 1, incrementalRefreshNotSupported: true,
+        lastRefreshStartTimeEpoch: 0,
+        lastRefreshEndTimeEpoch: NOW_EPOCH - 3599 // Refreshed just under 1 hour ago -> should be removed
+      };
+
+      const result: ViewAndLevel[] = await filter.filterAll([staleMv, recentMv]);
+      expect(result).toHaveLength(1);
+      expect(result[0].mvName).toBe('stale');
+    });
+
+    it('should default to a 0-second delay if environment variables are not set', async () => {
+      const filter = new StaleMaterializedViewFilter({}); // Empty env
+      
+      // With a 0 delay, any view refreshed in the past should be kept
+      const mv = {
+        mvName: 'any-mv', mvSchemaName: 's', mvLevel: 1, incrementalRefreshNotSupported: false,
+        lastRefreshStartTimeEpoch: 0,
+        lastRefreshEndTimeEpoch: NOW_EPOCH - 1 // Refreshed 1 second ago
+      };
+      
+      const result = await filter.filterAll([mv]);
+      expect(result).toHaveLength(1);
+    });
+
+    it('should throw an error if an environment variable is not a valid number', () => {
+      const mockEnv = { INCREMENTAL_MV_MIN_INTERVAL: 'not-a-number' };
+      
+      expect(() => new StaleMaterializedViewFilter(mockEnv))
+        .toThrow('Error parsing INCREMENTAL_MV_MIN_INTERVAL environment variable');
+    });
+  });
+
+
+  // --- 2. FILTERING LOGIC TESTS ---
+  // These tests remain the same as they were already testing the public API.
+  // =======================================================================
+  describe('filterAll (Comprehensive)', () => {
+    
+    const NOW_DATE = new Date('2025-09-12T09:00:00.000Z');
+    const NOW_EPOCH = Math.ceil(NOW_DATE.getTime() / 1000);
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(NOW_DATE);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const mockEnv: NodeJS.ProcessEnv = {
+        INCREMENTAL_MV_MIN_INTERVAL: '600',      // 10 minutes
+        NOT_INCREMENTAL_MV_MIN_INTERVAL: '7200'  // 2 hours
+    };
+
+    const staleIncrementalMv: ViewAndLevel = {
+      mvName: 'stale_incremental', mvSchemaName: 'test', mvLevel: 1,
+      incrementalRefreshNotSupported: false,
+      lastRefreshStartTimeEpoch: 0,
+      lastRefreshEndTimeEpoch: NOW_EPOCH - 900 // 15 mins ago
+    };
+
+    const recentIncrementalMv: ViewAndLevel = {
+      mvName: 'recent_incremental', mvSchemaName: 'test', mvLevel: 1,
+      incrementalRefreshNotSupported: false,
+      lastRefreshStartTimeEpoch: 0,
+      lastRefreshEndTimeEpoch: NOW_EPOCH - 300 // 5 mins ago
+    };
+    
+    const staleNonIncrementalMv: ViewAndLevel = {
+      mvName: 'stale_non_incremental', mvSchemaName: 'test', mvLevel: 2,
+      incrementalRefreshNotSupported: true,
+      lastRefreshStartTimeEpoch: 0,
+      lastRefreshEndTimeEpoch: NOW_EPOCH - 10800 // 3 hours ago
+    };
+
+    const recentNonIncrementalMv: ViewAndLevel = {
+      mvName: 'recent_non_incremental', mvSchemaName: 'test', mvLevel: 2,
+      incrementalRefreshNotSupported: true,
+      lastRefreshStartTimeEpoch: 0,
+      lastRefreshEndTimeEpoch: NOW_EPOCH - 3600 // 1 hour ago
+    };
+
+    it('should keep views that are older than their respective minimum delay', async () => {
+      const filter = new StaleMaterializedViewFilter(mockEnv);
+      const allMvs = [staleIncrementalMv, staleNonIncrementalMv];
+      
+      const result = await filter.filterAll(allMvs);
+      
+      expect(result).toEqual([staleIncrementalMv, staleNonIncrementalMv]);
+    });
+
+    it('should remove views that are more recent than their respective minimum delay', async () => {
+      const filter = new StaleMaterializedViewFilter(mockEnv);
+      const allMvs = [recentIncrementalMv, recentNonIncrementalMv];
+      
+      let totalRemoved = -1;
+      let removed: ViewAndLevel[] = [];
+      const logger = (mv, index ) => {
+        if( mv ) {
+            removed.push( mv );
+        }
+        else {
+            totalRemoved = index;
+        }
+      }
+
+      const result = await filter.filterAll(allMvs, logger );
+
+      expect(result).toEqual([]);
+      expect( totalRemoved ).toBe(2);
+      expect( removed ).toStrictEqual( allMvs );
+    });
+
+    it('should correctly filter a mixed list of stale and recent views', async () => {
+      const filter = new StaleMaterializedViewFilter(mockEnv);
+      const allMvs = [
+        staleIncrementalMv,     // Keep
+        recentIncrementalMv,    // Remove
+        staleNonIncrementalMv,  // Keep
+        recentNonIncrementalMv, // Remove
+      ];
+      
+      const result = await filter.filterAll(allMvs);
+      
+      expect(result).toHaveLength(2);
+      expect(result).toEqual([staleIncrementalMv, staleNonIncrementalMv]);
+    });
+    
+    it('should remove a view refreshed exactly on the delay boundary', async () => {
+      const filter = new StaleMaterializedViewFilter(mockEnv);
+      
+      // Refreshed exactly 10 minutes ago. The condition `last < now - delay`
+      // becomes `(now - 600) < (now - 600)`, which is false. So it is removed.
+      const boundaryMv: ViewAndLevel = {
+        mvName: 'boundary_incremental', mvSchemaName: 'test', mvLevel: 1,
+        incrementalRefreshNotSupported: false,
+        lastRefreshStartTimeEpoch: 0,
+        lastRefreshEndTimeEpoch: NOW_EPOCH - 600
+      };
+
+      const result = await filter.filterAll([boundaryMv]);
+      expect(result).toHaveLength(0);
+    });
+
+    it('should return an empty array if the input list is empty', async () => {
+      const filter = new StaleMaterializedViewFilter(mockEnv);
+      const result = await filter.filterAll([]);
+      expect(result).toEqual([]);
+    });
+
+  });
+});

--- a/lambdas/nodejs/analytics-refresh-mv/test/unit/StaleMaterializedViewFilter.test.ts
+++ b/lambdas/nodejs/analytics-refresh-mv/test/unit/StaleMaterializedViewFilter.test.ts
@@ -35,8 +35,8 @@ describe('StaleMaterializedViewFilter', () => {
       vi.useRealTimers();
     });
 
-    it('should apply the INCREMENTAL_MV_MIN_INTERVAL correctly', async () => {
-      const mockEnv = { INCREMENTAL_MV_MIN_INTERVAL: '300' }; // 5 minutes
+    it('should apply the INCREMENTAL_MV_MIN_INTERVAL_SECONDS correctly', async () => {
+      const mockEnv = { INCREMENTAL_MV_MIN_INTERVAL_SECONDS: '300' }; // 5 minutes
       const filter = new StaleMaterializedViewFilter(mockEnv);
       
       const staleMv: ViewAndLevel = {
@@ -55,8 +55,8 @@ describe('StaleMaterializedViewFilter', () => {
       expect(result[0].mvName).toBe('stale');
     });
 
-    it('should apply the NOT_INCREMENTAL_MV_MIN_INTERVAL correctly', async () => {
-      const mockEnv = { NOT_INCREMENTAL_MV_MIN_INTERVAL: '3600' }; // 1 hour
+    it('should apply the NOT_INCREMENTAL_MV_MIN_INTERVAL_SECONDS correctly', async () => {
+      const mockEnv = { NOT_INCREMENTAL_MV_MIN_INTERVAL_SECONDS: '3600' }; // 1 hour
       const filter = new StaleMaterializedViewFilter(mockEnv);
       
       const staleMv: ViewAndLevel = {
@@ -90,10 +90,10 @@ describe('StaleMaterializedViewFilter', () => {
     });
 
     it('should throw an error if an environment variable is not a valid number', () => {
-      const mockEnv = { INCREMENTAL_MV_MIN_INTERVAL: 'not-a-number' };
+      const mockEnv = { INCREMENTAL_MV_MIN_INTERVAL_SECONDS: 'not-a-number' };
       
       expect(() => new StaleMaterializedViewFilter(mockEnv))
-        .toThrow('Error parsing INCREMENTAL_MV_MIN_INTERVAL environment variable');
+        .toThrow('Error parsing INCREMENTAL_MV_MIN_INTERVAL_SECONDS environment variable');
     });
   });
 
@@ -116,8 +116,8 @@ describe('StaleMaterializedViewFilter', () => {
     });
 
     const mockEnv: NodeJS.ProcessEnv = {
-        INCREMENTAL_MV_MIN_INTERVAL: '600',      // 10 minutes
-        NOT_INCREMENTAL_MV_MIN_INTERVAL: '7200'  // 2 hours
+        INCREMENTAL_MV_MIN_INTERVAL_SECONDS: '600',      // 10 minutes
+        NOT_INCREMENTAL_MV_MIN_INTERVAL_SECONDS: '7200'  // 2 hours
     };
 
     const staleIncrementalMv: ViewAndLevel = {

--- a/lambdas/nodejs/analytics-refresh-mv/test/unit/groupMaterializedViews.test.ts
+++ b/lambdas/nodejs/analytics-refresh-mv/test/unit/groupMaterializedViews.test.ts
@@ -1,17 +1,28 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { groupMaterializedViews } from '../../src/groupMaterializedViews'; 
-import { ViewAndLevel } from '../../src/MaterializedViewHelper'; 
+import { ViewAndLevel } from '../../src/ViewAndLevel'; 
 
+// We spy on console.error to ensure it's called without polluting test logs.
+vi.spyOn(console, 'error').mockImplementation(() => {});
+vi.spyOn(console, 'log').mockImplementation(() => {});
+
+const ancillaryData = { 
+  incrementalRefreshNotSupported: false, 
+  lastRefreshStartTimeEpoch: 0, 
+  lastRefreshEndTimeEpoch: 1000, 
+  lastRefreshStartTime: "Start time", 
+  lastRefreshEndTime: "End time", 
+}
 
 // --- Test Suite ---
 describe('groupMaterializedViews', () => {
 
   it('should group views by their level and sort the groups in ascending order', () => {
     // ARRANGE: Input with mixed, unsorted levels
-    const view1: ViewAndLevel = { mvSchemaName: 's1', mvName: 'view_a', mvLevel: 1 };
-    const view2: ViewAndLevel = { mvSchemaName: 's2', mvName: 'view_b', mvLevel: 2 };
-    const view3: ViewAndLevel = { mvSchemaName: 's1', mvName: 'view_c', mvLevel: 1 };
-    const view4: ViewAndLevel = { mvSchemaName: 's3', mvName: 'view_d', mvLevel: 3 };
+    const view1: ViewAndLevel = { mvSchemaName: 's1', mvName: 'view_a', mvLevel: 1, ...ancillaryData };
+    const view2: ViewAndLevel = { mvSchemaName: 's2', mvName: 'view_b', mvLevel: 2, ...ancillaryData };
+    const view3: ViewAndLevel = { mvSchemaName: 's1', mvName: 'view_c', mvLevel: 1, ...ancillaryData };
+    const view4: ViewAndLevel = { mvSchemaName: 's3', mvName: 'view_d', mvLevel: 3, ...ancillaryData };
     
     const views: ViewAndLevel[] = [view2, view4, view1, view3];
 
@@ -40,9 +51,9 @@ describe('groupMaterializedViews', () => {
 
   it('should place all items into a single group if they have the same level', () => {
     // ARRANGE
-    const view1: ViewAndLevel = { mvSchemaName: 's1', mvName: 'view_a', mvLevel: 5 };
-    const view2: ViewAndLevel = { mvSchemaName: 's2', mvName: 'view_b', mvLevel: 5 };
-    const view3: ViewAndLevel = { mvSchemaName: 's1', mvName: 'view_c', mvLevel: 5 };
+    const view1: ViewAndLevel = { mvSchemaName: 's1', mvName: 'view_a', mvLevel: 5, ...ancillaryData };
+    const view2: ViewAndLevel = { mvSchemaName: 's2', mvName: 'view_b', mvLevel: 5, ...ancillaryData };
+    const view3: ViewAndLevel = { mvSchemaName: 's1', mvName: 'view_c', mvLevel: 5, ...ancillaryData };
 
     const views: ViewAndLevel[] = [view1, view2, view3];
 
@@ -56,8 +67,8 @@ describe('groupMaterializedViews', () => {
   
   it('should correctly handle non-sequential levels and maintain sort order', () => {
     // ARRANGE: Input with a gap in levels (e.g., 10 and 12, but no 11)
-    const view1: ViewAndLevel = { mvSchemaName: 's1', mvName: 'view_a', mvLevel: 12 };
-    const view2: ViewAndLevel = { mvSchemaName: 's2', mvName: 'view_b', mvLevel: 10 };
+    const view1: ViewAndLevel = { mvSchemaName: 's1', mvName: 'view_a', mvLevel: 12, ...ancillaryData };
+    const view2: ViewAndLevel = { mvSchemaName: 's2', mvName: 'view_b', mvLevel: 10, ...ancillaryData };
 
     const views: ViewAndLevel[] = [view1, view2];
 

--- a/lambdas/nodejs/analytics-refresh-mv/test/unit/index_instantiations_fails.test.ts
+++ b/lambdas/nodejs/analytics-refresh-mv/test/unit/index_instantiations_fails.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { MaterializedViewHelper, ViewAndLevel } from '../../src/MaterializedViewHelper';
+import { MaterializedViewHelper } from '../../src/MaterializedViewHelper';
 import { RedshiftDataWrapper } from '../../src/RedshiftDataWrapper';
 import { RedshiftClusterChecker } from '../../src/RedshiftClusterChecker';
+import { ViewAndLevel } from '../../src/ViewAndLevel';
 
 // N.B.: This file is separated from index.test.ts because the use of mockImplementation 
 //       on RedshiftDataWrapper and MaterializedViewHelper interfere with others tests.
@@ -10,6 +11,8 @@ import { RedshiftClusterChecker } from '../../src/RedshiftClusterChecker';
 
 // We spy on console.error to ensure it's called without polluting test logs.
 vi.spyOn(console, 'error').mockImplementation(() => {});
+vi.spyOn(console, 'log').mockImplementation(() => {});
+
 
 // Mock all dependencies before they are imported by the handler.
 
@@ -71,12 +74,19 @@ describe('Lambda Handler', () => {
   });
 
   // --- Mock Data ---
+  const ancillaryData = { 
+    incrementalRefreshNotSupported: false, 
+    lastRefreshStartTimeEpoch: 0, 
+    lastRefreshEndTimeEpoch: 1000, 
+    lastRefreshStartTime: "Start time", 
+    lastRefreshEndTime: "End time", 
+  }
   const MOCK_VIEWS_LEVEL_1: ViewAndLevel[] = [
-    { mvSchemaName: 's1', mvName: 'view_a', mvLevel: 1 },
-    { mvSchemaName: 's1', mvName: 'view_b', mvLevel: 1 },
+    { mvSchemaName: 's1', mvName: 'view_a', mvLevel: 1, ... ancillaryData },
+    { mvSchemaName: 's1', mvName: 'view_b', mvLevel: 1, ... ancillaryData },
   ];
   const MOCK_VIEWS_LEVEL_2: ViewAndLevel[] = [
-    { mvSchemaName: 's2', mvName: 'view_c', mvLevel: 2 },
+    { mvSchemaName: 's2', mvName: 'view_c', mvLevel: 2, ... ancillaryData },
   ];
 
   // --- INSTANTIATION FAILURE SCENARIO TESTS ---


### PR DESCRIPTION
Add support to minimum interval between two refresh of the same materialized view.

Added two parameters:
- `INCREMENTAL_MV_MIN_INTERVAL`, this optional parameter contain the minimum number of seconds between two refresh of the same materialized view. This parameter apply to materialized views that are refreshed incrementally. If not given default value is 0.
- `NOT_INCREMENTAL_MV_MIN_INTERVAL`, this optional parameter contain the minimum number of seconds between two refresh of the same materialized view. This parameter apply to materialized views that are refreshed with full recalculation and materialized views with refresh issues. If not given default value is 0. Technically this parameter is used for every materialized view with `state` field of table [SVV_MV_INFO](https://docs.aws.amazon.com/redshift/latest/dg/r_SVV_MV_INFO.html) not equal to 1.


Also done:
 - Log improvement
 - Test modification to support new feature.
